### PR TITLE
Added support for full EZCONNECT format 

### DIFF
--- a/fastldr-args-parser/src/main/java/org/agileworks/fastldr/args/UserID.java
+++ b/fastldr-args-parser/src/main/java/org/agileworks/fastldr/args/UserID.java
@@ -6,6 +6,7 @@ public class UserID {
 	private String user;
 	private String password;
 	private String hostname;
+	private String port = "1521";
 	private String service;
 
 	public UserID(String uid) throws ParseException {
@@ -24,12 +25,23 @@ public class UserID {
 		password = userPart.substring(slashSign + 1).trim();
 
 		String hostPart = uid.substring(uid.indexOf("@") + 1);
+		if (hostPart.startsWith("//")) {
+		    hostPart = hostPart.substring(2);
+        }
 		slashSign = hostPart.indexOf("/");
 		if (slashSign == -1)
 			throw new ParseException("Invalid format of USERID parameter (missing '/' divider of hostname/instance)");
 
-		hostname = hostPart.substring(0, slashSign).trim();
-		service = hostPart.substring(slashSign + 1).trim();
+		int colonSign = hostPart.indexOf(":");
+		if (colonSign == -1) {
+            hostname = hostPart.substring(0, slashSign).trim();
+            service = hostPart.substring(slashSign + 1).trim();
+        } else {
+            hostname = hostPart.substring(0, colonSign).trim();
+            port = hostPart.substring(colonSign + 1, slashSign).trim();
+            service = hostPart.substring(slashSign + 1).trim();
+        }
+
 	}
 
 	public String getUser() {
@@ -56,7 +68,16 @@ public class UserID {
 		this.hostname = hostname;
 	}
 
-	public String getService() {
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getService() {
 		return service;
 	}
 
@@ -73,6 +94,8 @@ public class UserID {
 		sb.append(password);
 		sb.append("@");
 		sb.append(hostname);
+		sb.append(":");
+		sb.append(port);
 		sb.append("/");
 		sb.append(service);
 		

--- a/fastldr/src/main/java/org/agileworks/fastldr/OracleDataSource.java
+++ b/fastldr/src/main/java/org/agileworks/fastldr/OracleDataSource.java
@@ -38,7 +38,8 @@ public class OracleDataSource {
 		sb.append("jdbc:oracle:thin:@");
 		UserID userID = cmdArguments.getUserID();
 		sb.append("//");
-		sb.append(userID.getHostname()).append(":1521");
+		sb.append(userID.getHostname()).append(":");
+		sb.append(userID.getPort());
 		sb.append('/').append(userID.getService());
 		return sb.toString();
 	}

--- a/fastldr/src/test/java/org/agileworks/fastldr/CmdArgumentsParserTest.java
+++ b/fastldr/src/test/java/org/agileworks/fastldr/CmdArgumentsParserTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.*;
 public class CmdArgumentsParserTest {
 
 	@Test
-	public void testArgs() {
+	public void testArgsDefaultPort() {
 		String args = "USERID=FooUser/FooUserPass@10.211.55.4/AGILEWORKS,PARFILE=/development/agileworks/scratch/sqlloader/Return.par,LOG=/development/agileworks/web/app/log/Return_1.log,BAD=/development/agileworks/custom/export/error/Return_1.bad,DISCARD=/development/agileworks/custom/export/error/Return_1.dis,SKIP=1,LOAD=1000000";
 
 		CmdArgumentsParser p = new CmdArgumentsParser(new StringReader(args));
@@ -26,7 +26,7 @@ public class CmdArgumentsParserTest {
 
 		assertNotNull(cmdArguments);
 		assertEquals(CmdArguments.TYPE_PAR, cmdArguments.getType());
-		assertEquals("FooUser/FooUserPass@10.211.55.4/AGILEWORKS", cmdArguments.getUserID().toString());
+		assertEquals("FooUser/FooUserPass@10.211.55.4:1521/AGILEWORKS", cmdArguments.getUserID().toString());
 		assertEquals("/development/agileworks/scratch/sqlloader/Return.par", cmdArguments.getParFile());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.bad", cmdArguments.getBadFile());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.dis", cmdArguments.getDiscardFile());
@@ -35,9 +35,54 @@ public class CmdArgumentsParserTest {
 		assertEquals(1, cmdArguments.getSkip());
 
 		assertEquals("10.211.55.4", cmdArguments.getUserID().getHostname());
+		assertEquals("1521", cmdArguments.getUserID().getPort()); // default port
 		assertEquals("AGILEWORKS", cmdArguments.getUserID().getService());
 		assertEquals("FooUser", cmdArguments.getUserID().getUser());
 		assertEquals("FooUserPass", cmdArguments.getUserID().getPassword());
+	}
+
+	@Test
+	public void testArgsCustomPort() {
+		String args = "USERID=FooUser1/FooUserPass1@myHost:1234/orcl1";
+
+		CmdArgumentsParser p = new CmdArgumentsParser(new StringReader(args));
+		CmdArguments cmdArguments = null;
+		try {
+			cmdArguments = p.Start();
+		} catch (ParseException e) {
+			//e.printStackTrace();
+		}
+
+		assertNotNull(cmdArguments);
+		assertEquals("FooUser1/FooUserPass1@myHost:1234/orcl1", cmdArguments.getUserID().toString());
+
+		assertEquals("myHost", cmdArguments.getUserID().getHostname());
+		assertEquals("1234", cmdArguments.getUserID().getPort());
+		assertEquals("orcl1", cmdArguments.getUserID().getService());
+		assertEquals("FooUser1", cmdArguments.getUserID().getUser());
+		assertEquals("FooUserPass1", cmdArguments.getUserID().getPassword());
+	}
+
+	@Test
+	public void testArgsCustomPortAndSlashes() {
+		String args = "USERID=FooUser2/FooUserPass2@//myHost:5678/orcl2";
+
+		CmdArgumentsParser p = new CmdArgumentsParser(new StringReader(args));
+		CmdArguments cmdArguments = null;
+		try {
+			cmdArguments = p.Start();
+		} catch (ParseException e) {
+			//e.printStackTrace();
+		}
+
+		assertNotNull(cmdArguments);
+		assertEquals("FooUser2/FooUserPass2@myHost:5678/orcl2", cmdArguments.getUserID().toString());
+
+		assertEquals("myHost", cmdArguments.getUserID().getHostname());
+		assertEquals("5678", cmdArguments.getUserID().getPort());
+		assertEquals("orcl2", cmdArguments.getUserID().getService());
+		assertEquals("FooUser2", cmdArguments.getUserID().getUser());
+		assertEquals("FooUserPass2", cmdArguments.getUserID().getPassword());
 	}
 
 	@Test
@@ -114,7 +159,7 @@ public class CmdArgumentsParserTest {
 
 		assertNotNull(cmdArguments);
 		assertEquals(CmdArguments.TYPE_UNKNOWN, cmdArguments.getType());
-		assertEquals("FooUser/FooUserPass@10.211.55.4/AGILEWORKS", cmdArguments.getUserID().toString());
+		assertEquals("FooUser/FooUserPass@10.211.55.4:1521/AGILEWORKS", cmdArguments.getUserID().toString());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.bad", cmdArguments.getBadFile());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.dis", cmdArguments.getDiscardFile());
 		assertEquals("/development/agileworks/web/app/log/Return_1.log", cmdArguments.getLogFile());
@@ -141,7 +186,7 @@ public class CmdArgumentsParserTest {
 
 		assertNotNull(cmdArguments);
 		assertEquals(CmdArguments.TYPE_CONTROL, cmdArguments.getType());
-		assertEquals("FooUser/FooUserPass@10.211.55.4/AGILEWORKS", cmdArguments.getUserID().toString());
+		assertEquals("FooUser/FooUserPass@10.211.55.4:1521/AGILEWORKS", cmdArguments.getUserID().toString());
 		assertEquals("/development/agileworks/scratch/sqlloader/Return.ctl", cmdArguments.getControlFile());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.bad", cmdArguments.getBadFile());
 		assertEquals("/development/agileworks/custom/export/error/Return_1.dis", cmdArguments.getDiscardFile());
@@ -150,6 +195,7 @@ public class CmdArgumentsParserTest {
 		assertEquals(1, cmdArguments.getSkip());
 
 		assertEquals("10.211.55.4", cmdArguments.getUserID().getHostname());
+		assertEquals("1521", cmdArguments.getUserID().getPort());
 		assertEquals("AGILEWORKS", cmdArguments.getUserID().getService());
 		assertEquals("FooUser", cmdArguments.getUserID().getUser());
 		assertEquals("FooUserPass", cmdArguments.getUserID().getPassword());


### PR DESCRIPTION
Added support for full EZCONNECT format `username/password@[//]host[:port][/service_name]` - the `//` leading slashes and a custom `port`